### PR TITLE
Update the gitignore to ignore xccheckout files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ profile
 DerivedData
 .idea/
 *.hmap
+*.xccheckout
 
 #CocoaPods
 Pods


### PR DESCRIPTION
In Xcode 5 and 6, there are xccheckout files.  These shouldn't be in the repo.

This PR ignores these files.
