### PR TITLE
DemoMonkey persists to both bplist and XML under the demoMonkey extension.

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -49,14 +49,32 @@
 
 #import "AppDelegate.h"
 #import "MyDocument.h"
-
+#import "DocumentController.h"
 
 static NSString *DMKOpenUntitledDocumentOnLaunchKey = @"openUntitledDocumentOnLaunch";
 NSString *DMKDisplayWindowAlphaKey = @"displayWindowAlpha";
 NSString *DMKDisplayToolTipsKey = @"displayToolTips";
 
+@interface AppDelegate ()
+@property (nonatomic) DocumentController *documentController;
+@end
 
 @implementation AppDelegate
+
+#pragma mark - Lifecycle
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        // This is (all that's) necessary to make DocumentController
+        //   be used instead of NSDocumentController.
+        //   We could just alloc/init it,
+        //   but it is nicer to have a reference to our global object.
+        _documentController = [[DocumentController alloc] init];
+    }
+    return self;
+}
 
 #pragma mark -
 #pragma mark Services

--- a/BNRAttributeMacros.h
+++ b/BNRAttributeMacros.h
@@ -1,0 +1,36 @@
+//
+//  AttributeMacros.h
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/21/15.
+//
+//
+
+#ifndef DemoMonkey_AttributeMacros_h
+#define DemoMonkey_AttributeMacros_h
+
+#ifndef BNR_NONNULL
+    #if __has_attribute(__nonnull)
+        #define BNR_NONNULL __nonnull
+    #else
+        #define BNR_NONNULL
+    #endif
+#endif
+
+#ifndef BNR_NULLABLE
+    #if __has_attribute(__nullable)
+        #define BNR_NULLABLE __nullable
+    #else
+        #define BNR_NULLABLE
+    #endif
+#endif
+
+#ifndef BNR_NULL_UNSPECIFIED
+    #if __has_attribute(__null_unspecified)
+        #define BNR_NULL_UNSPECIFIED __null_unspecified
+    #else
+        #define BNR_NULL_UNSPECIFIED
+    #endif
+#endif
+
+#endif

--- a/DemoMonkey.xcodeproj/project.pbxproj
+++ b/DemoMonkey.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		28DABBB80FBF22D500694A30 /* ReadMe.txt in Resources */ = {isa = PBXBuildFile; fileRef = 28DABBB70FBF22D500694A30 /* ReadMe.txt */; };
 		28DABBBB0FBF233F00694A30 /* DMKArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28DABBBA0FBF233F00694A30 /* DMKArrayController.m */; };
 		4364BBA21ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */; };
+		4364BBA91ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4364BBA81ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m */; };
 		4383A90F1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */; };
 		4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A9121AB62C9300084CF2 /* Step+XMLAdditions.m */; };
 		696661D41AB61CDC0054CC80 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 696661D31AB61CDC0054CC80 /* Images.xcassets */; };
@@ -53,6 +54,8 @@
 		32DBCF750370BD2300C91783 /* DemoMonkey_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemoMonkey_Prefix.pch; sourceTree = "<group>"; };
 		4364BBA01ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSKeyedUnarchiver+BNRAdditions.h"; sourceTree = "<group>"; };
 		4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSKeyedUnarchiver+BNRAdditions.m"; sourceTree = "<group>"; };
+		4364BBA71ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSXMLDocument+BNRAdditions.h"; sourceTree = "<group>"; };
+		4364BBA81ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSXMLDocument+BNRAdditions.m"; sourceTree = "<group>"; };
 		4383A90D1AB6246500084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSWindow+RSWGracefulEndEditingAdditions.h"; sourceTree = "<group>"; };
 		4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSWindow+RSWGracefulEndEditingAdditions.m"; sourceTree = "<group>"; };
 		4383A9111AB62C9300084CF2 /* Step+XMLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Step+XMLAdditions.h"; sourceTree = "<group>"; };
@@ -188,6 +191,8 @@
 				4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */,
 				4364BBA01ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.h */,
 				4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */,
+				4364BBA71ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.h */,
+				4364BBA81ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -273,6 +278,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4364BBA91ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m in Sources */,
 				8D15AC310486D014006FF6A4 /* MyDocument.m in Sources */,
 				8D15AC320486D014006FF6A4 /* main.m in Sources */,
 				4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */,

--- a/DemoMonkey.xcodeproj/project.pbxproj
+++ b/DemoMonkey.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		28B2AF1E080F91AA00403FAE /* Step.m in Sources */ = {isa = PBXBuildFile; fileRef = 28B2AF1D080F91AA00403FAE /* Step.m */; };
 		28DABBB80FBF22D500694A30 /* ReadMe.txt in Resources */ = {isa = PBXBuildFile; fileRef = 28DABBB70FBF22D500694A30 /* ReadMe.txt */; };
 		28DABBBB0FBF233F00694A30 /* DMKArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28DABBBA0FBF233F00694A30 /* DMKArrayController.m */; };
+		4364BBA21ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */; };
 		4383A90F1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */; };
 		4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A9121AB62C9300084CF2 /* Step+XMLAdditions.m */; };
 		696661D41AB61CDC0054CC80 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 696661D31AB61CDC0054CC80 /* Images.xcassets */; };
@@ -50,6 +51,8 @@
 		2A37F4C4FDCFA73011CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		2A37F4C5FDCFA73011CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		32DBCF750370BD2300C91783 /* DemoMonkey_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemoMonkey_Prefix.pch; sourceTree = "<group>"; };
+		4364BBA01ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSKeyedUnarchiver+BNRAdditions.h"; sourceTree = "<group>"; };
+		4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSKeyedUnarchiver+BNRAdditions.m"; sourceTree = "<group>"; };
 		4383A90D1AB6246500084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSWindow+RSWGracefulEndEditingAdditions.h"; sourceTree = "<group>"; };
 		4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSWindow+RSWGracefulEndEditingAdditions.m"; sourceTree = "<group>"; };
 		4383A9111AB62C9300084CF2 /* Step+XMLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Step+XMLAdditions.h"; sourceTree = "<group>"; };
@@ -183,6 +186,8 @@
 			children = (
 				4383A90D1AB6246500084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.h */,
 				4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */,
+				4364BBA01ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.h */,
+				4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -272,6 +277,7 @@
 				8D15AC320486D014006FF6A4 /* main.m in Sources */,
 				4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */,
 				28B2AE25080F575700403FAE /* DisplayController.m in Sources */,
+				4364BBA21ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m in Sources */,
 				28B2AE26080F575700403FAE /* EditController.m in Sources */,
 				28B2AF1E080F91AA00403FAE /* Step.m in Sources */,
 				289915970818FD6700EA8C28 /* AppDelegate.m in Sources */,

--- a/DemoMonkey.xcodeproj/project.pbxproj
+++ b/DemoMonkey.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		2A37F4C4FDCFA73011CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		2A37F4C5FDCFA73011CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		32DBCF750370BD2300C91783 /* DemoMonkey_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemoMonkey_Prefix.pch; sourceTree = "<group>"; };
+		434843AC1ABDFE0E0049EB4E /* BNRAttributeMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BNRAttributeMacros.h; sourceTree = "<group>"; };
 		4364BBA01ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSKeyedUnarchiver+BNRAdditions.h"; sourceTree = "<group>"; };
 		4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSKeyedUnarchiver+BNRAdditions.m"; sourceTree = "<group>"; };
 		4364BBA41ABB2025000F2E76 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
@@ -159,6 +160,7 @@
 			children = (
 				32DBCF750370BD2300C91783 /* DemoMonkey_Prefix.pch */,
 				2A37F4B0FDCFA73011CA2CEA /* main.m */,
+				434843AC1ABDFE0E0049EB4E /* BNRAttributeMacros.h */,
 			);
 			name = "Other Sources";
 			sourceTree = "<group>";

--- a/DemoMonkey.xcodeproj/project.pbxproj
+++ b/DemoMonkey.xcodeproj/project.pbxproj
@@ -116,8 +116,6 @@
 		28EB618D0FB8A38F00739008 /* Application Delegate */ = {
 			isa = PBXGroup;
 			children = (
-				289915950818FD6700EA8C28 /* AppDelegate.h */,
-				289915960818FD6700EA8C28 /* AppDelegate.m */,
 			);
 			name = "Application Delegate";
 			sourceTree = "<group>";
@@ -125,6 +123,7 @@
 		2A37F4AAFDCFA73011CA2CEA /* DemoMonkey */ = {
 			isa = PBXGroup;
 			children = (
+				4364BBA31ABB2006000F2E76 /* Application */,
 				28DABBB70FBF22D500694A30 /* ReadMe.txt */,
 				2A37F4ABFDCFA73011CA2CEA /* Document Controllers */,
 				28EB618D0FB8A38F00739008 /* Application Delegate */,
@@ -182,6 +181,15 @@
 				1058C7A8FEA54F5311CA2CBB /* Other Frameworks */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4364BBA31ABB2006000F2E76 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				289915950818FD6700EA8C28 /* AppDelegate.h */,
+				289915960818FD6700EA8C28 /* AppDelegate.m */,
+			);
+			name = Application;
 			sourceTree = "<group>";
 		};
 		4383A90C1AB6241C00084CF2 /* Helpers */ = {

--- a/DemoMonkey.xcodeproj/project.pbxproj
+++ b/DemoMonkey.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		28DABBB80FBF22D500694A30 /* ReadMe.txt in Resources */ = {isa = PBXBuildFile; fileRef = 28DABBB70FBF22D500694A30 /* ReadMe.txt */; };
 		28DABBBB0FBF233F00694A30 /* DMKArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28DABBBA0FBF233F00694A30 /* DMKArrayController.m */; };
 		4364BBA21ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */; };
+		4364BBA61ABB2025000F2E76 /* DocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4364BBA51ABB2025000F2E76 /* DocumentController.m */; };
 		4364BBA91ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4364BBA81ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m */; };
 		4383A90F1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */; };
 		4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A9121AB62C9300084CF2 /* Step+XMLAdditions.m */; };
@@ -54,6 +55,8 @@
 		32DBCF750370BD2300C91783 /* DemoMonkey_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemoMonkey_Prefix.pch; sourceTree = "<group>"; };
 		4364BBA01ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSKeyedUnarchiver+BNRAdditions.h"; sourceTree = "<group>"; };
 		4364BBA11ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSKeyedUnarchiver+BNRAdditions.m"; sourceTree = "<group>"; };
+		4364BBA41ABB2025000F2E76 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
+		4364BBA51ABB2025000F2E76 /* DocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DocumentController.m; sourceTree = "<group>"; };
 		4364BBA71ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSXMLDocument+BNRAdditions.h"; sourceTree = "<group>"; };
 		4364BBA81ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSXMLDocument+BNRAdditions.m"; sourceTree = "<group>"; };
 		4383A90D1AB6246500084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSWindow+RSWGracefulEndEditingAdditions.h"; sourceTree = "<group>"; };
@@ -188,6 +191,8 @@
 			children = (
 				289915950818FD6700EA8C28 /* AppDelegate.h */,
 				289915960818FD6700EA8C28 /* AppDelegate.m */,
+				4364BBA41ABB2025000F2E76 /* DocumentController.h */,
+				4364BBA51ABB2025000F2E76 /* DocumentController.m */,
 			);
 			name = Application;
 			sourceTree = "<group>";
@@ -289,6 +294,7 @@
 				4364BBA91ABB20C0000F2E76 /* NSXMLDocument+BNRAdditions.m in Sources */,
 				8D15AC310486D014006FF6A4 /* MyDocument.m in Sources */,
 				8D15AC320486D014006FF6A4 /* main.m in Sources */,
+				4364BBA61ABB2025000F2E76 /* DocumentController.m in Sources */,
 				4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */,
 				28B2AE25080F575700403FAE /* DisplayController.m in Sources */,
 				4364BBA21ABB0059000F2E76 /* NSKeyedUnarchiver+BNRAdditions.m in Sources */,

--- a/DemoMonkey.xcodeproj/project.pbxproj
+++ b/DemoMonkey.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		28DABBB80FBF22D500694A30 /* ReadMe.txt in Resources */ = {isa = PBXBuildFile; fileRef = 28DABBB70FBF22D500694A30 /* ReadMe.txt */; };
 		28DABBBB0FBF233F00694A30 /* DMKArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28DABBBA0FBF233F00694A30 /* DMKArrayController.m */; };
 		4383A90F1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */; };
+		4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4383A9121AB62C9300084CF2 /* Step+XMLAdditions.m */; };
 		696661D41AB61CDC0054CC80 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 696661D31AB61CDC0054CC80 /* Images.xcassets */; };
 		775DFF38067A968500C5B868 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */; };
 		8D15AC2D0486D014006FF6A4 /* MainMenu.nib in Resources */ = {isa = PBXBuildFile; fileRef = 2A37F4B6FDCFA73011CA2CEA /* MainMenu.nib */; };
@@ -51,6 +52,8 @@
 		32DBCF750370BD2300C91783 /* DemoMonkey_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemoMonkey_Prefix.pch; sourceTree = "<group>"; };
 		4383A90D1AB6246500084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSWindow+RSWGracefulEndEditingAdditions.h"; sourceTree = "<group>"; };
 		4383A90E1AB6246600084CF2 /* NSWindow+RSWGracefulEndEditingAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSWindow+RSWGracefulEndEditingAdditions.m"; sourceTree = "<group>"; };
+		4383A9111AB62C9300084CF2 /* Step+XMLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Step+XMLAdditions.h"; sourceTree = "<group>"; };
+		4383A9121AB62C9300084CF2 /* Step+XMLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Step+XMLAdditions.m"; sourceTree = "<group>"; };
 		696661D31AB61CDC0054CC80 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = DemoMonkey/Images.xcassets; sourceTree = "<group>"; };
 		7788DA0506752A1600599AAD /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
 		8D15AC360486D014006FF6A4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -189,6 +192,8 @@
 			children = (
 				28B2AF1C080F91AA00403FAE /* Step.h */,
 				28B2AF1D080F91AA00403FAE /* Step.m */,
+				4383A9111AB62C9300084CF2 /* Step+XMLAdditions.h */,
+				4383A9121AB62C9300084CF2 /* Step+XMLAdditions.m */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -265,6 +270,7 @@
 			files = (
 				8D15AC310486D014006FF6A4 /* MyDocument.m in Sources */,
 				8D15AC320486D014006FF6A4 /* main.m in Sources */,
+				4383A9131AB62C9300084CF2 /* Step+XMLAdditions.m in Sources */,
 				28B2AE25080F575700403FAE /* DisplayController.m in Sources */,
 				28B2AE26080F575700403FAE /* EditController.m in Sources */,
 				28B2AF1E080F91AA00403FAE /* Step.m in Sources */,

--- a/DemoMonkey_Prefix.pch
+++ b/DemoMonkey_Prefix.pch
@@ -51,4 +51,6 @@
     #import <Foundation/Foundation.h>
     #import <CoreData/CoreData.h>
     #import <Cocoa/Cocoa.h>
+
+    #import "BNRAttributeMacros.h"
 #endif

--- a/DocumentController.h
+++ b/DocumentController.h
@@ -1,0 +1,31 @@
+//
+//  DocumentController.h
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/19/15.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+
+extern NSString * const DocumentControllerErrorDomain;
+
+typedef NS_ENUM(NSInteger, DocumentControllerErrorCode) {
+    DocumentControllerErrorCodeNoError,
+    DocumentControllerErrorCodeUnparseable,
+};
+
+extern NSString * const MyDocumentTypeNameArchive;
+extern NSString * const MyDocumentTypeNameXML;
+
+typedef NS_ENUM(NSInteger, MyDocumentType) {
+    MyDocumentTypeUnknown = 0,
+    MyDocumentTypeBinaryPlist,
+    MyDocumentTypeXML,
+};
+
+MyDocumentType MyDocumentTypeFromMyDocumentTypeName(NSString *name);
+
+@interface DocumentController : NSDocumentController
+
+@end

--- a/DocumentController.m
+++ b/DocumentController.m
@@ -59,7 +59,7 @@ mutableDictionary[name] = @((type));   \
     //    - Nate 2015.03.18
     
     NSData *data = [NSData dataWithContentsOfURL:url
-                                         options:0
+                                         options:NSDataReadingMappedIfSafe
                                            error:outError];
     if (!data) {
         return nil;

--- a/DocumentController.m
+++ b/DocumentController.m
@@ -1,0 +1,86 @@
+//
+//  DocumentController.m
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/19/15.
+//
+//
+
+#import "DocumentController.h"
+#import "NSXMLDocument+BNRAdditions.h"
+#import "NSKeyedUnarchiver+BNRAdditions.h"
+
+NSString * const MyDocumentTypeNameArchive = @"com.bignerdranch.demomonkey.property-list";
+NSString * const MyDocumentTypeNameXML = @"com.bignerdranch.demomonkey.xml";
+
+NSString * const DocumentControllerErrorDomain = @"DocumentControllerErrorDomain";
+
+MyDocumentType MyDocumentTypeFromMyDocumentTypeName(NSString *name) {
+    static NSDictionary *dictionary = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableDictionary *mutableDictionary = [[NSMutableDictionary alloc] init];
+        
+#define SetTypeForName( type , name ) do { \
+mutableDictionary[name] = @((type));   \
+} while(0);
+        
+        SetTypeForName(MyDocumentTypeBinaryPlist, MyDocumentTypeNameArchive);
+        SetTypeForName(MyDocumentTypeXML, MyDocumentTypeNameXML);
+        
+#undef SetTypeForName
+        
+        dictionary = [mutableDictionary copy];
+    });
+    
+    NSNumber *typeNumber = dictionary[name];
+    if (typeNumber) {
+        return typeNumber.integerValue;
+    } else {
+        return MyDocumentTypeUnknown;
+    }
+}
+
+@implementation DocumentController
+
+- (NSString *)typeForContentsOfURL:(NSURL *)url error:(NSError *__autoreleasing *)outError
+{
+    // OS X with HFS can't know the correct UTI to give us:
+    //    it determines the UTI on the basis of an extension and a creator code.
+    //    The first UTI using that extension
+    //    exported by the app with the appropriate creator code
+    //    will be used.
+    //    In this case, that UTI is simply com.bignerdranch.demomonkey.file.
+    //    To determine the actual format of the file,
+    //    we have a couple of options:
+    //    (1) shell out to file (man file)
+    //    (2) try to parse as one format, then fall back to the other(s)
+    //    The second approach is followed here.
+    //    - Nate 2015.03.18
+    
+    NSData *data = [NSData dataWithContentsOfURL:url
+                                         options:0
+                                           error:outError];
+    if (!data) {
+        return nil;
+    }
+    
+    if ([NSXMLDocument bnr_canParseData:data withOptions:0]) {
+        return MyDocumentTypeNameXML;
+    }
+    if ([NSKeyedUnarchiver bnr_canParseData:data]) {
+        return MyDocumentTypeNameArchive;
+    }
+    
+    if (outError) {
+        NSString *localizedDescription = [NSString stringWithFormat:@"The specified file (%@) could not be read.", url];
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : localizedDescription};
+        NSError *error = [NSError errorWithDomain:DocumentControllerErrorDomain
+                                             code:DocumentControllerErrorCodeUnparseable
+                                         userInfo:userInfo];
+        *outError = error;
+    }
+    return nil;
+}
+
+@end

--- a/DocumentController.m
+++ b/DocumentController.m
@@ -73,8 +73,8 @@ mutableDictionary[name] = @((type));   \
     }
     
     if (outError) {
-        NSString *localizedDescription = [NSString stringWithFormat:@"The specified file (%@) could not be read.", url];
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : localizedDescription};
+        NSString *informativeErrorAlertText = [NSString stringWithFormat:@"The specified file (%@) could not be read.", url.path];
+        NSDictionary *userInfo = @{NSLocalizedRecoverySuggestionErrorKey : informativeErrorAlertText};
         NSError *error = [NSError errorWithDomain:DocumentControllerErrorDomain
                                              code:DocumentControllerErrorCodeUnparseable
                                          userInfo:userInfo];

--- a/Info.plist
+++ b/Info.plist
@@ -15,22 +15,50 @@
 			<string></string>
 			<key>CFBundleTypeMIMETypes</key>
 			<array>
-				<string>text/xml</string>
+				<string>application/x-plist</string>
 			</array>
 			<key>CFBundleTypeName</key>
-			<string>XML</string>
+			<string>DemoMonkey Archive</string>
 			<key>CFBundleTypeOSTypes</key>
 			<array>
 				<string>????</string>
 			</array>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.bignerdranch.demomonkey.property-list</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<false/>
 			<key>NSDocumentClass</key>
 			<string>MyDocument</string>
-			<key>NSPersistentStoreTypeKey</key>
-			<string>XML</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>demoMonkey</string>
+			</array>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>text/xml</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>DemoMonkey XML</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>????</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.bignerdranch.demomonkey.xml</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<integer>0</integer>
+			<key>NSDocumentClass</key>
+			<string>MyDocument</string>
 		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
@@ -154,6 +182,68 @@
 			<array>
 				<string>public.plain-text</string>
 			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array/>
+			<key>UTTypeDescription</key>
+			<string>DemoMonkey File</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.bignerdranch.demomonkey.file</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>demoMonkey</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+                <string>com.bignerdranch.demomonkey.file</string>
+				<string>com.apple.property-list</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>DemoMonkey Archive</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.bignerdranch.demomonkey.property-list</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>demoMonkey</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-plist</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+                <string>com.bignerdranch.demomonkey.file</string>
+				<string>public.xml</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>DemoMonkey XML</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.bignerdranch.demomonkey.xml</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>demoMonkey</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>text/xml</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/MyDocument.m
+++ b/MyDocument.m
@@ -209,15 +209,11 @@
 #pragma mark -
 #pragma mark Object lifecycle
 
-- (instancetype) init {
+- (instancetype)init {
     if (self = [super init]) {
         _steps = [[NSMutableArray alloc] init];
     }
     return self;    
 }
-
-
-
-
 
 @end

--- a/MyDocument.m
+++ b/MyDocument.m
@@ -53,6 +53,17 @@
 #import "DisplayController.h"
 #import "EditController.h"
 #import "Step.h"
+#import "Step+XMLAdditions.h"
+#import "NSKeyedUnarchiver+BNRAdditions.h"
+#import "DocumentController.h"
+
+static NSString * const MyDocumentErrorDomain = @"com.bignerdranch.demomonkey.MyDocumentErrorDomain";
+
+typedef NS_ENUM(NSInteger, MyDocumentErrorCode) {
+    MyDocumentErrorCodeNoError = 0,
+    MyDocumentErrorCodeXMLInvalidStep,
+    MyDocumentErrorCodeArchiveInvalid,
+};
 
 @interface MyDocument () {
     NSMutableArray *_steps;
@@ -109,17 +120,137 @@
 #pragma mark Reading and writing file
 
 - (BOOL)readFromData:(NSData *)data ofType:(NSString *)typeName error:(NSError **)outError {
-
-    NSArray *newSteps = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-    self.steps = newSteps;
-    return YES;
+    switch (MyDocumentTypeFromMyDocumentTypeName(typeName)) {
+        case MyDocumentTypeXML: {
+            return [self readFromXMLData:data error:outError];
+        } break;
+        case MyDocumentTypeBinaryPlist: {
+            return [self readFromArchiveData:data error:outError];
+        } break;
+        case MyDocumentTypeUnknown: {
+            NSAssert(NO, @"MyDocument tried to open a document of unknown type.  This should have been handled in the DocumentController.  Programmer error!");
+            __builtin_unreachable();
+        }
+    }
 }
 
+- (BOOL)readFromXMLData:(NSData *)data error:(NSError **)outError
+{
+    BOOL success = NO;
+    NSError *error = nil;
+    NSArray *steps = nil;
+    
+    NSError *parseXMLError = nil;
+    NSXMLDocument *document = [[NSXMLDocument alloc] initWithData:data options:0 error:&parseXMLError];
+    NSXMLElement *root = document.rootElement;
+    
+    NSError *addError = nil;
+    
+    NSMutableArray *mutableSteps = [[NSMutableArray alloc] init];
+    
+    for (NSXMLElement *childElement in [root elementsForName:StepXMLAdditionsKeyStep]) {
+        Step * __nullable step = [[Step alloc] initWithXMLElement:childElement];
+        if (step) {
+            [mutableSteps addObject:step];
+        } else {
+            NSDictionary *userInfo = @{NSLocalizedRecoverySuggestionErrorKey : @"Invalid XML file!  Found a step which could not be initialized."};
+            addError = [NSError errorWithDomain:MyDocumentErrorDomain
+                                           code:MyDocumentErrorCodeXMLInvalidStep
+                                       userInfo:userInfo];
+            mutableSteps = nil;
+            break;
+        }
+    }
+    
+    if (mutableSteps) {
+        success = YES;
+        error = nil;
+        steps = [mutableSteps copy];
+    } else {
+        success = NO;
+        error = addError;
+        steps = nil;
+    }
+    
+    self.steps = steps;
+    if (outError) {
+        *outError = error;
+    }
+    return success;
+}
+
+- (BOOL)readFromArchiveData:(NSData *)data error:(NSError **)outError
+{
+    BOOL success = NO;
+    NSError *error = nil;
+    NSArray *steps = nil;
+    
+    NSError *unarchiveError = nil;
+    id unarchivedSteps =  [NSKeyedUnarchiver bnr_unarchiveObjectWithData:data
+                                                                   error:&unarchiveError
+                                                              errorMaker:^(NSException * exception) {
+                                                                  NSDictionary *userInfo = @{NSLocalizedRecoverySuggestionErrorKey : @"Invalid archive!"};
+                                                                  NSError *result = [NSError errorWithDomain:MyDocumentErrorDomain
+                                                                                                        code:MyDocumentErrorCodeArchiveInvalid
+                                                                                                    userInfo:userInfo];
+                                                                  return result;
+                                                              }];
+    
+    if (!!unarchivedSteps) {
+        success = YES;
+        error = nil;
+        steps = unarchivedSteps;
+    } else {
+        success = NO;
+        error = unarchiveError;
+        steps = nil;
+    }
+
+    self.steps = steps;
+    if (outError) {
+        *outError = error;
+    }
+    return success;
+}
 
 - (NSData *)dataOfType:(NSString *)typeName error:(NSError **)outError {
-    return [NSKeyedArchiver archivedDataWithRootObject:self.steps];
+    switch (MyDocumentTypeFromMyDocumentTypeName(typeName)) {
+        case MyDocumentTypeBinaryPlist: {
+            return [self archiveDataWithError:outError];
+        } break;
+        case MyDocumentTypeXML: {
+            return [self xmlDataWithError:outError];
+        } break;
+        case MyDocumentTypeUnknown: {
+            NSAssert(NO, @"Trying to save demoMonkey document by document type is unknown.  The document type should have been handled by the DocumentController.  Programmer error!");
+            __builtin_unreachable();
+        } break;
+    }
 }
 
+- (NSData *)xmlDataWithError:(NSError **)outError
+{
+    NSArray *stepElements = ^{
+        NSMutableArray *mutableResult = [[NSMutableArray alloc] init];
+        
+        for (Step *step in self.steps) {
+            [mutableResult addObject:step.XMLElement];
+        }
+        
+        return [mutableResult copy];
+    }();
+    
+    NSXMLElement *root = [NSXMLElement elementWithName:@"demoMonkey"
+                                              children:stepElements
+                                            attributes:nil];
+    NSXMLDocument *document = [NSXMLDocument documentWithRootElement:root];
+    return [document XMLDataWithOptions:NSXMLNodePrettyPrint];
+}
+
+- (NSData *)archiveDataWithError:(NSError **)outError
+{
+    return [NSKeyedArchiver archivedDataWithRootObject:self.steps];
+}
 
 #pragma mark -
 #pragma mark Managing window controllers

--- a/MyDocument.m
+++ b/MyDocument.m
@@ -149,7 +149,7 @@ typedef NS_ENUM(NSInteger, MyDocumentErrorCode) {
     NSMutableArray *mutableSteps = [[NSMutableArray alloc] init];
     
     for (NSXMLElement *childElement in [root elementsForName:StepXMLAdditionsKeyStep]) {
-        Step * __nullable step = [[Step alloc] initWithXMLElement:childElement];
+        Step * BNR_NULLABLE step = [[Step alloc] initWithXMLElement:childElement];
         if (step) {
             [mutableSteps addObject:step];
         } else {

--- a/NSKeyedUnarchiver+BNRAdditions.h
+++ b/NSKeyedUnarchiver+BNRAdditions.h
@@ -1,0 +1,31 @@
+//
+//  NSKeyedUnarchiver+BNRAdditions.h
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/19/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+extern NSString * const BNRNSKeyedArchiverErrorDomain;
+
+typedef NS_ENUM(NSInteger, BNRNSKeyedArchiverErrorCode) {
+    BNRNSKeyedArchiverErrorCodeNoError = 0,
+    BNRNSKeyedArchiverErrorCodeInvalidArchive,
+};
+
+@interface NSKeyedUnarchiver (BNRAdditions)
+
++ (id)bnr_unarchiveObjectWithData:(NSData *)data
+                            error:(NSError **)outError;
++ (id)bnr_unarchiveObjectWithData:(NSData *)data
+                            error:(NSError **)outError
+                       errorMaker:(NSError *(^)(NSException *))block;
+
++ (BOOL)bnr_canParseData:(NSData *)data
+                   error:(NSError **)outError
+              errorMaker:(NSError *(^)(NSException *))block;
++ (BOOL)bnr_canParseData:(NSData *)data;
+
+@end

--- a/NSKeyedUnarchiver+BNRAdditions.m
+++ b/NSKeyedUnarchiver+BNRAdditions.m
@@ -1,0 +1,67 @@
+//
+//  NSKeyedUnarchiver+BNRAdditions.m
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/19/15.
+//
+//
+
+#import "NSKeyedUnarchiver+BNRAdditions.h"
+
+NSString * const BNRNSKeyedArchiverErrorDomain = @"com.bignerdranch.nsadditions.keyedarchiver.errordomain";
+
+@implementation NSKeyedUnarchiver (BNRAdditions)
+
++ (id)bnr_unarchiveObjectWithData:(NSData *)data
+                              error:(NSError **)outError
+{
+    return [self bnr_unarchiveObjectWithData:data
+                                       error:outError
+                                  errorMaker:nil];
+}
+
++ (id)bnr_unarchiveObjectWithData:(NSData *)data
+                      error:(NSError **)outError
+                 errorMaker:(NSError *(^)(NSException *))block
+{
+    @try {
+        // This can throw.
+        id result = [self unarchiveObjectWithData:data];
+        
+        return result;
+    }
+    @catch (NSException *exception) {
+        if (outError) {
+            *outError = ^{
+                if (block) {
+                    return block(exception);
+                } else {
+                    NSDictionary *userInfo = @{NSLocalizedRecoverySuggestionErrorKey : @"Invalid archive!"};
+                    NSError *result = [NSError errorWithDomain:BNRNSKeyedArchiverErrorDomain
+                                                          code:BNRNSKeyedArchiverErrorCodeInvalidArchive
+                                                      userInfo:userInfo];
+                    return result;
+                }
+            }();
+        }
+        return NO;
+    }
+}
+
++ (BOOL)bnr_canParseData:(NSData *)data
+                   error:(NSError **)outError
+              errorMaker:(NSError *(^)(NSException *))block
+{
+    return !![self bnr_unarchiveObjectWithData:data
+                                         error:outError
+                                    errorMaker:block];
+}
+
++ (BOOL)bnr_canParseData:(NSData *)data
+{
+    return [self bnr_canParseData:data
+                            error:NULL
+                       errorMaker:nil];
+}
+
+@end

--- a/NSXMLDocument+BNRAdditions.h
+++ b/NSXMLDocument+BNRAdditions.h
@@ -1,0 +1,20 @@
+//
+//  NSXMLDocument+BNRAdditions.h
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/19/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSXMLDocument (BNRAdditions)
+
++ (BOOL)bnr_canParseData:(NSData *)data
+             withOptions:(NSUInteger)mask;
++ (BOOL)bnr_canParseData:(NSData *)data
+             withOptions:(NSUInteger)mask
+                document:(NSXMLDocument **)documentOut
+                   error:(NSError **)errorOut;
+
+@end

--- a/NSXMLDocument+BNRAdditions.m
+++ b/NSXMLDocument+BNRAdditions.m
@@ -1,0 +1,41 @@
+//
+//  NSXMLDocument+BNRAdditions.m
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/19/15.
+//
+//
+
+#import "NSXMLDocument+BNRAdditions.h"
+
+@implementation NSXMLDocument (BNRAdditions)
+
++ (BOOL)bnr_canParseData:(NSData *)data
+             withOptions:(NSUInteger)mask
+{
+    return [self bnr_canParseData:data
+                      withOptions:mask
+                         document:NULL
+                            error:NULL];
+}
+
++ (BOOL)bnr_canParseData:(NSData *)data
+             withOptions:(NSUInteger)mask
+                document:(NSXMLDocument **)documentOut
+                   error:(NSError **)errorOut
+{
+    NSError *error = nil;
+    NSXMLDocument *document = [[NSXMLDocument alloc] initWithData:data
+                                                          options:mask
+                                                            error:&error];
+    
+    if (documentOut) {
+        *documentOut = document;
+    }
+    if (errorOut) {
+        *errorOut = error;
+    }
+    return !!document;
+}
+
+@end

--- a/Step+XMLAdditions.h
+++ b/Step+XMLAdditions.h
@@ -8,11 +8,11 @@
 
 #import "Step.h"
 
-extern NSString * __nonnull const StepXMLAdditionsKeyStep;
+extern NSString * BNR_NONNULL const StepXMLAdditionsKeyStep;
 
 @interface Step (XMLAdditions)
 
-- (nonnull NSXMLElement *)XMLElement;
-- (nullable Step *)initWithXMLElement:(nonnull NSXMLElement *)element;
+- (BNR_NONNULL NSXMLElement *)XMLElement;
+- (BNR_NULLABLE Step *)initWithXMLElement:(BNR_NONNULL NSXMLElement *)element;
 
 @end

--- a/Step+XMLAdditions.h
+++ b/Step+XMLAdditions.h
@@ -1,0 +1,18 @@
+//
+//  Step+XMLAdditions.h
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/15/15.
+//
+//
+
+#import "Step.h"
+
+extern NSString * __nonnull const StepXMLAdditionsKeyStep;
+
+@interface Step (XMLAdditions)
+
+- (nonnull NSXMLElement *)XMLElement;
+- (nullable Step *)initWithXMLElement:(nonnull NSXMLElement *)element;
+
+@end

--- a/Step+XMLAdditions.m
+++ b/Step+XMLAdditions.m
@@ -8,15 +8,15 @@
 
 #import "Step+XMLAdditions.h"
 
-NSString * const __nonnull StepXMLAdditionsKeyStep = @"step";
+NSString * const BNR_NONNULL StepXMLAdditionsKeyStep = @"step";
 
-static NSString * __nonnull const StepXMLAdditionsKeyTableSummary = @"tableSummary";
-static NSString * __nonnull const StepXMLAdditionsKeyBody = @"body";
-static NSString * __nonnull const StepXMLAdditionsKeyTooltip = @"tooltip";
+static NSString * BNR_NONNULL const StepXMLAdditionsKeyTableSummary = @"tableSummary";
+static NSString * BNR_NONNULL const StepXMLAdditionsKeyBody = @"body";
+static NSString * BNR_NONNULL const StepXMLAdditionsKeyTooltip = @"tooltip";
 
 @implementation Step (XMLAdditions)
 
-- (nonnull NSXMLElement *)XMLElement {
+- (BNR_NONNULL NSXMLElement *)XMLElement {
     NSXMLElement *theTableSummaryElement = [NSXMLElement elementWithName:StepXMLAdditionsKeyTableSummary
                                                              stringValue:self.tableSummary];
     NSXMLNode *bodyText = [[NSXMLNode alloc] initWithKind:NSXMLTextKind options:NSXMLNodeIsCDATA];
@@ -32,7 +32,7 @@ static NSString * __nonnull const StepXMLAdditionsKeyTooltip = @"tooltip";
     return result;
 }
 
-- (nullable Step *)initWithXMLElement:(nonnull NSXMLElement *)element {
+- (BNR_NULLABLE Step *)initWithXMLElement:(BNR_NONNULL NSXMLElement *)element {
     self = [super init];
     if (self) {
         NSXMLElement *tableSummaryElement = [element elementsForName:StepXMLAdditionsKeyTableSummary].firstObject;

--- a/Step+XMLAdditions.m
+++ b/Step+XMLAdditions.m
@@ -19,8 +19,11 @@ static NSString * __nonnull const StepXMLAdditionsKeyTooltip = @"tooltip";
 - (nonnull NSXMLElement *)XMLElement {
     NSXMLElement *theTableSummaryElement = [NSXMLElement elementWithName:StepXMLAdditionsKeyTableSummary
                                                              stringValue:self.tableSummary];
+    NSXMLNode *bodyText = [[NSXMLNode alloc] initWithKind:NSXMLTextKind options:NSXMLNodeIsCDATA];
+    bodyText.stringValue = self.body;
     NSXMLElement *theBody = [NSXMLElement elementWithName:StepXMLAdditionsKeyBody
-                                              stringValue:self.body];
+                                                 children:@[bodyText]
+                                               attributes:nil];
     NSXMLElement *theTooltip = [NSXMLElement elementWithName:StepXMLAdditionsKeyTooltip
                                                  stringValue:self.tooltip];
     NSXMLElement *result = [NSXMLElement elementWithName:StepXMLAdditionsKeyStep

--- a/Step+XMLAdditions.m
+++ b/Step+XMLAdditions.m
@@ -1,0 +1,49 @@
+//
+//  Step+XMLAdditions.m
+//  DemoMonkey
+//
+//  Created by Nate Chandler on 3/15/15.
+//
+//
+
+#import "Step+XMLAdditions.h"
+
+NSString * const __nonnull StepXMLAdditionsKeyStep = @"step";
+
+static NSString * __nonnull const StepXMLAdditionsKeyTableSummary = @"tableSummary";
+static NSString * __nonnull const StepXMLAdditionsKeyBody = @"body";
+static NSString * __nonnull const StepXMLAdditionsKeyTooltip = @"tooltip";
+
+@implementation Step (XMLAdditions)
+
+- (nonnull NSXMLElement *)XMLElement {
+    NSXMLElement *theTableSummaryElement = [NSXMLElement elementWithName:StepXMLAdditionsKeyTableSummary
+                                                             stringValue:self.tableSummary];
+    NSXMLElement *theBody = [NSXMLElement elementWithName:StepXMLAdditionsKeyBody
+                                              stringValue:self.body];
+    NSXMLElement *theTooltip = [NSXMLElement elementWithName:StepXMLAdditionsKeyTooltip
+                                                 stringValue:self.tooltip];
+    NSXMLElement *result = [NSXMLElement elementWithName:StepXMLAdditionsKeyStep
+                                                children:@[theTableSummaryElement, theBody, theTooltip]
+                                              attributes:nil];
+    return result;
+}
+
+- (nullable Step *)initWithXMLElement:(nonnull NSXMLElement *)element {
+    self = [super init];
+    if (self) {
+        NSXMLElement *tableSummaryElement = [element elementsForName:StepXMLAdditionsKeyTableSummary].firstObject;
+        NSXMLElement *bodyElement = [element elementsForName:StepXMLAdditionsKeyBody].firstObject;
+        NSXMLElement *tooltipElement = [element elementsForName:StepXMLAdditionsKeyTooltip].firstObject;
+        if (tableSummaryElement && bodyElement && tooltipElement) {
+            self.tableSummary = tableSummaryElement.stringValue;
+            self.body = bodyElement.stringValue;
+            self.tooltip = tooltipElement.stringValue;
+        } else {
+            return nil;
+        }
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
Previously, DemoMonkey persisted only to archive.  This was unfortunate because binary blobs do not work well with version control.  This PR allows DemoMonkey documents to be saved as (pretty-printed) XML, a version control -compatible format.

Both file formats use the same extension.  This results in some complexity.  See the commit messages ( in particular https://github.com/bignerdranch/DemoMonkey/commit/a0a35576eba1bd31f9f5689ef2fbc601cf409c45 ) and the comments ( in particular https://github.com/bignerdranch/DemoMonkey/commit/a0a35576eba1bd31f9f5689ef2fbc601cf409c45#diff-eb91140c423ae407922f4e8adeeb98adR48 ).

This PR is a cleaning up and reworking of https://github.com/bignerdranch/DemoMonkey/pull/6 .

Closes #3
